### PR TITLE
remove unneeded gitignore lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /bin
 /build
 /geckodriver.log
-/venv


### PR DESCRIPTION
- coverage-html: coverage>=6.2 writes a .gitignore file
- mypy_cache: mypy>=0.770 writes a .gitignore file
- pytest_cache: pytest>=3.8.1 writes a .gitignore file
- venv: virtualenv>=20.0.21 writes a .gitignore file

Committed via https://github.com/asottile/all-repos